### PR TITLE
Usim changes to support Usim debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 machdep
-usim
 machdep.h
 **/*.o
+**/*.a
+*.bak
+*.sublime-workspace
+usim

--- a/Makefile
+++ b/Makefile
@@ -2,46 +2,61 @@ DEBUG		= -O3
 CXX			= g++ --std=c++17 -Wall -Wextra -Werror -flto
 CC			= gcc --std=c9x -Wall -Werror
 CCFLAGS		= $(DEBUG)
-CPPFLAGS	= -D_POSIX_SOURCE
+CPPFLAGS	= -D_POSIX_SOURCE -I . -I usimdbg -o $(@)
 LDFLAGS		= -flto
 
 LIB_SRCS	= usim.cpp mc6809.cpp mc6809in.cpp mc6850.cpp memory.cpp
 
-SRCS		= ${LIB_SRCS} main.cpp term.cpp
-OBJS		= $(SRCS:.cpp=.o)
+OBJS		= $(LIB_SRCS:.cpp=.o)
 BIN			= usim
 
-LIBS		=
+LIB			= libusim.a
 
-$(BIN):		$(OBJS)
-	$(CXX) -o $(@) $(CCFLAGS) $(LDFLAGS) $(OBJS) $(LIBS)
+all: $(BIN)
 
-.SUFFIXES:	.cpp
+$(LIB): $(OBJS) # $(LIB)($(OBJS))
+	ar crs $(@) $^
+	ranlib $(@)
+
+$(BIN):	$(LIB) main.o term.o
+	$(CXX) $(CCFLAGS) $(LDFLAGS) main.o term.o -L. -lusim -o $(@) 
+
+.SUFFIXES: .cpp
 
 .cpp.o:
 	$(CXX) $(CPPFLAGS) $(CCFLAGS) -c $<
 
-$(OBJS):	machdep.h
+$(OBJS): machdep.h
 
-machdep:	machdep.o
+machdep: machdep.o
 	$(CC) -o $(@) $(CCFLAGS) $(LDFLAGS) machdep.o
 
-machdep.h:	machdep
+machdep.h: machdep
 	./machdep $(@)
 
 clean:
-	$(RM) -f machdep.h machdep.o machdep $(BIN) $(OBJS)
+	$(RM) machdep.h machdep.o machdep $(BIN) $(OBJS) main.o term.o $(LIB) 
 
-depend:		machdep.h
-	makedepend $(SRCS)
+depend:	machdep.h
+	makedepend 	$(LIB_SRCS) main.cpp term.cpp
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
-usim.o: usim.h device.h typedefs.h machdep.h
-mc6809.o: mc6809.h usim.h device.h wiring.h typedefs.h machdep.h bits.h
-mc6809in.o: mc6809.h usim.h device.h typedefs.h machdep.h bits.h
-memory.o: memory.h device.h typedefs.h
-mc6850.o: mc6850.h device.h wiring.h typedefs.h term.h bits.h
-term.o: mc6850.h term.h typedefs.h
-main.o: mc6809.h usim.h device.h typedefs.h machdep.h mc6850.h term.h
-main.o: memory.h
+usim.o: usim.h device.h typedefs.h /usr/include/stdint.h memory.h wiring.h
+usim.o: bits.h
+mc6809.o: mc6809.h wiring.h usim.h device.h typedefs.h /usr/include/stdint.h
+mc6809.o: memory.h bits.h machdep.h
+mc6809in.o: mc6809.h wiring.h usim.h device.h typedefs.h
+mc6809in.o: /usr/include/stdint.h memory.h bits.h machdep.h
+mc6850.o: mc6850.h device.h typedefs.h /usr/include/stdint.h wiring.h bits.h
+memory.o: memory.h device.h typedefs.h /usr/include/stdint.h
+main.o: /usr/include/unistd.h /usr/include/features.h
+main.o: /usr/include/stdc-predef.h mc6809.h wiring.h usim.h device.h
+main.o: typedefs.h /usr/include/stdint.h memory.h bits.h machdep.h mc6850.h
+main.o: term.h /usr/include/termios.h
+term.o: term.h mc6850.h device.h typedefs.h /usr/include/stdint.h wiring.h
+term.o: /usr/include/termios.h /usr/include/features.h
+term.o: /usr/include/stdc-predef.h /usr/include/unistd.h
+term.o: /usr/include/ncurses.h /usr/include/ncurses_dll.h
+term.o: /usr/include/stdio.h /usr/include/unctrl.h /usr/include/curses.h
+term.o: /usr/include/string.h /usr/include/strings.h

--- a/main.cpp
+++ b/main.cpp
@@ -25,8 +25,9 @@ int main(int argc, char *argv[])
 	const Word rom_base = 0xe000;
 	const Word rom_size = 0x10000 - rom_base;
 
-	Terminal term;
-	mc6809	cpu;
+	mc6809			cpu;
+	Terminal 		term;
+
 	auto ram = std::make_shared<RAM>(ram_size);
 	auto rom = std::make_shared<ROM>(rom_size);
 	auto acia = std::make_shared<mc6850>(term);

--- a/mc6809.cpp
+++ b/mc6809.cpp
@@ -462,10 +462,8 @@ void mc6809::execute_instruction()
 	}
 }
 
-void mc6809::pre_exec()
+void mc6809::regs()
 {
-	if (!m_trace) return;
-
 	char flags[] = "EFHINZVC";
 	for (uint8_t i = 0, mask = 0x80; mask; ++i, mask >>= 1) {
 		if ((cc.all & mask) == 0) {
@@ -474,6 +472,13 @@ void mc6809::pre_exec()
 	}
 	fprintf(stderr, "PC:%04X CC:%s S:%04X U:%04X A:%02X B:%02X X:%04X Y:%04X DP:%02X\r\n",
 		pc, flags, s, u, a, b, x, y, dp);
+}
+
+void mc6809::pre_exec()
+{
+	if (!m_trace) return;
+
+	regs();
 }
 
 void mc6809::post_exec()

--- a/mc6809.h
+++ b/mc6809.h
@@ -17,6 +17,9 @@
 #include "machdep.h"
 #endif
 
+#ifndef MC6809_H_
+#define MC6809_H_
+
 class mc6809 : virtual public USimMotorola {
 
 protected: // Processor addressing modes
@@ -81,8 +84,6 @@ private:	// internal processor state
 	bool			nmi_previous;
 
 private:	// instruction and operand fetch and decode
-	Byte&			byterefreg(int);
-	Word&			wordrefreg(int);
 	Word&			ix_refreg(Byte);
 
 	void			fetch_instruction();
@@ -215,11 +216,17 @@ public:		// external signal pins
 	InputPin		IRQ, FIRQ, NMI;
 
 public:
-				mc6809();		// public constructor
+					mc6809();		// public constructor
 	virtual			~mc6809();		// public destructor
 
-	virtual void		reset();		// CPU reset
-	virtual void		tick();
+	virtual void	reset();		// CPU reset
+	virtual void	tick();
+
+	virtual void	regs();
+
+	Byte&			byterefreg(int);
+	Word&			wordrefreg(int);
+
 };
 
 inline void mc6809::do_br(const char *mnemonic, bool test)
@@ -262,3 +269,5 @@ inline void mc6809::do_pul(Word& sp, Word& val)
 	val  = read(sp++) << 8;
 	val |= read(sp++);
 }
+
+#endif /* MC6809_H_ */

--- a/memory.cpp
+++ b/memory.cpp
@@ -10,7 +10,7 @@
 #include <cstdlib>
 #include "memory.h"
 
-static Byte fread_hex_byte(FILE *fp)
+Byte fread_hex_byte(FILE *fp)
 {
 	char			str[3];
 	long			l;
@@ -23,7 +23,7 @@ static Byte fread_hex_byte(FILE *fp)
 	return (Byte)(l & 0xff);
 }
 
-static Word fread_hex_word(FILE *fp)
+Word fread_hex_word(FILE *fp)
 {
 	Word		ret;
 

--- a/term.cpp
+++ b/term.cpp
@@ -118,12 +118,12 @@ void Terminal::write(Byte ch)
 
 void Terminal::tilde_escape_help()
 {
-	printf("\r\nSupported escape sequences:\r\n");
-	printf(" ~. - terminate emulator\r\n");
-	// printf(" ~r - reboot emulator\r\n");
-	printf(" ~? - this message\r\n");
-	printf(" ~~ - send the escape character by typing it twice\r\n");
-	printf("(Note that escapes are only recognized immediately after newline.)\r\n");
+	fprintf(stderr, "\r\nSupported escape sequences:\r\n");
+	fprintf(stderr, " ~. - terminate emulator\r\n");
+	fprintf(stderr, " ~? - this message\r\n");
+	fprintf(stderr, " ~~ - send the escape character by typing it twice\r\n");
+	tilde_escape_help_other();
+	fprintf(stderr, "(Note that escapes are only recognized immediately after newline.)\r\n");
 }
 
 bool Terminal::poll_read()
@@ -160,12 +160,10 @@ bool Terminal::poll_read()
 		case 2:
 			tilde_escape_phase = 0;
 			read_data_available = false;
+
 			switch (ch) {
 				case '~':
 					read_data_available = true;
-					break;
-				case 'r':
-				case 'R':
 					break;
 				case '.':
 					exit(0);
@@ -174,6 +172,7 @@ bool Terminal::poll_read()
 					tilde_escape_help();
 					break;
 				default:
+					tilde_escape_do_other(ch);
 					break;
 			}
 			break;
@@ -184,6 +183,15 @@ bool Terminal::poll_read()
 	}
 
 	return read_data_available;
+}
+
+void Terminal::tilde_escape_do_other(char ch)
+{
+	(void)ch;
+}
+
+void Terminal::tilde_escape_help_other()
+{
 }
 
 Byte Terminal::read()

--- a/term.h
+++ b/term.h
@@ -23,6 +23,8 @@ protected:
 	int					tilde_escape_phase = 0;
 
 	void				tilde_escape_help();
+	virtual void		tilde_escape_help_other();
+	virtual void 		tilde_escape_do_other(char ch);
 	bool				real_poll_read();
 	Byte				real_read();
 
@@ -38,7 +40,6 @@ public:
 	virtual bool		poll_read();
 	virtual void		write(Byte);
 	virtual Byte		read();
-
 
 // Public constructor and destructor
 public:

--- a/tests/test.s
+++ b/tests/test.s
@@ -9,7 +9,7 @@
 loop		cwai	#$bf
 		lda	inchar
 		jsr	puthexbyte
-		exg	a, b
+		exg	a,b
 		swi
 		bra	loop
 

--- a/tests/test_main.s
+++ b/tests/test_main.s
@@ -8,7 +8,7 @@ acia		equ	$c000
 
 inchar		equ	$00
 
-		setdp	$00
+;		setdp	$00
 
 ;
 ;		Start of System ROM
@@ -19,7 +19,7 @@ handle_reset	lds	#system_stack
 		ldu	#user_stack
 		orcc	#$50		; disable interrupts
 
-		leax    system_ready, pcr
+		leax    system_ready,pcr
 		lbsr    putstr
 
 		include "test.s"
@@ -72,7 +72,7 @@ str_dp		fcn	" DP:"
 str_x		fcn	"  X:"
 str_y		fcn	"  Y:"
 
-str_nl		fcc	13,10,0
+str_nl		fcb	13,10,0
 
 package_io
 
@@ -144,7 +144,8 @@ tolower_done	puls	cc
 		rts
 
 prompt_str	fcn	"> "
-system_ready	fcn	"System loaded and ready",13,10
+system_ready	fcc	"System loaded and ready"
+		fcb 	13,10+$80
 
 handle_irq	rti
 

--- a/typedefs.h
+++ b/typedefs.h
@@ -8,8 +8,16 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <cstddef>
 #include <cstdint>
+
+#else
+
+#include <stdint.h>
+
+#endif
 
 typedef uint8_t		Byte;
 typedef uint16_t	Word;

--- a/usim.h
+++ b/usim.h
@@ -35,7 +35,7 @@ protected:
 		Word		pc;
 
 // Generic read/write/execute functions
-protected:
+public:
 
 	virtual Byte		read(Word offset);
 	virtual Word		read_word(Word offset) = 0;
@@ -78,7 +78,7 @@ public:
 class USimMotorola : virtual public USim {
 
 // Memory access functions taking target byte order into account
-protected:
+public:
 	virtual Word		fetch_word();
 
 	virtual Word		read_word(Word offset);
@@ -89,7 +89,7 @@ protected:
 class USimIntel : virtual public USim {
 
 // Memory access functions taking target byte order into account
-protected:
+public:
 	virtual Word		fetch_word();
 
 	virtual Word		read_word(Word offset);

--- a/usim.sublime-project
+++ b/usim.sublime-project
@@ -1,0 +1,8 @@
+{
+	"folders":
+	[
+		{
+			"path": "/home/james/workspace/6809/tools/usim",
+		},
+	],
+}


### PR DESCRIPTION
Ray,
re
here are the changes to usim to support the debugger I have been working on [https://github.com/JNSpears/usimdbg]. All most all of the changes were to expose private data as protected for the derived debugger class to use, Here is a short summary of the changes:

- Creation of a library containing the core modules from usim.
- Factored out code in mc6809 that could be reused.
- Made several private methods protected to expose them to the debugger.
- Tweaked the Terminal::tilde_escape support to make it easier to add functionality.

I have a question what did you use to assemble the test files, I got errors using `lwasm` and `as9` on test_main.s?

--James.