### PR TITLE
Update mc6809in.cpp to remove read on CLR

### DIFF
--- a/mc6809in.cpp
+++ b/mc6809in.cpp
@@ -643,7 +643,7 @@ void mc6809::clr()
 {
 	insn = "CLR";
 	Word	addr = fetch_effective_address();
-	Byte	m = read(addr);
+	Byte	m;
 	help_clr(m);
 	write(addr, m);
 }


### PR DESCRIPTION
The CLR instruction should be a write-only operation. Removed the gratuitous read.